### PR TITLE
Omit unneeded path in Qt include

### DIFF
--- a/polkit-agent/src/PolkitListener.cpp
+++ b/polkit-agent/src/PolkitListener.cpp
@@ -22,7 +22,7 @@
 #include <PolkitQt1/Details>
 #include <PolkitQt1/Authority>
 #include <PolkitQt1/ActionDescription>
-#include <qt5/QtWidgets/qdialogbuttonbox.h>
+#include <qdialogbuttonbox.h>
 
 #include <QDebug>
 #include <QDesktopWidget>


### PR DESCRIPTION
In Arch we have Qt headers installed in /usr/include/qt instead of /usr/include/qt5, which fails the build here. Since we already use cmake to configure include path let's just omit the path to work on any system.